### PR TITLE
adding app label

### DIFF
--- a/gargoyle/models.py
+++ b/gargoyle/models.py
@@ -68,6 +68,7 @@ class Switch(models.Model):
         )
         verbose_name = _('switch')
         verbose_name_plural = _('switches')
+        app_label = 'gargoyle'
 
     def __init__(self, *args, **kwargs):
         if (


### PR DESCRIPTION
it is probably a better idea to reorganize the imports so the `gargoyle.models` doesn't get loaded during app initialization, but the import structure was kinda tangled and I think this is an easier solution that doesn't have any side-effects.
